### PR TITLE
Fix proxy always forward `GET` method of the HTTP

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ class HttpProxy {
       hostname: u.hostname,
       port: u.port || 80,
       path: u.path,
-      method: u.method || 'get',
-      headers: u.headers,
+      method: uReq.method || 'get',
+      headers: uReq.headers,
       agent: socksAgent
     }
     const pReq = http.request(options)


### PR DESCRIPTION
The proxy always sends the HTTP's `GET` method due to the result of url.parse doesn't contain `method` or `headers`.